### PR TITLE
Fixed issue with PRIVMSG

### DIFF
--- a/includes/PrivmsgCommand.hpp
+++ b/includes/PrivmsgCommand.hpp
@@ -14,6 +14,6 @@ class PrivmsgCommand : public ACommand {
 
 	public:
 		static std::unique_ptr<ACommand> create(std::string command, std::shared_ptr<Client>& client, State& state,
-			std::vector<std::string> args);
+			std::string target, std::string msg);
 		bool	execute() const override;
 };

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -66,16 +66,11 @@ bool	Parser::parseJoinCommand(std::shared_ptr<Client>& client, std::string& inpu
 }
 
 bool	Parser::parsePrivmsgCommand(std::shared_ptr<Client>& client, std::string& input, State& state) {
-	std::vector<std::string>	arg_vec;
-
 	std::string command = input.substr(0, input.find_first_of(' '));
 	input.erase(0, command.length() + 1);
-	while (!input.empty()) {
-		std::string	arg = input.substr(0, input.find_first_of(' '));
-		input.erase(0, arg.length() + 1);
-		arg_vec.push_back(arg);
-	}
-	std::unique_ptr<ACommand>	cmd = PrivmsgCommand::create(command, client, state, arg_vec);
+	std::string	target = input.substr(0, input.find_first_of(' '));
+	input.erase(0, target.length() + 1);
+	std::unique_ptr<ACommand>	cmd = PrivmsgCommand::create(command, client, state, target, input);
 	if (cmd == nullptr) {
 		return (false);
 	}

--- a/sources/PrivmsgCommand.cpp
+++ b/sources/PrivmsgCommand.cpp
@@ -4,11 +4,11 @@
 PrivmsgCommand::PrivmsgCommand(std::string command, std::shared_ptr<Client>& client, State& state) : ACommand(command, client, state) {}
 
 std::unique_ptr<ACommand>	PrivmsgCommand::create(std::string command, std::shared_ptr<Client>& client, State& state,
-	std::vector<std::string> args) {
+	std::string target, std::string msg) {
 		PrivmsgCommand*	cmd = new PrivmsgCommand(command, client, state);
 
-	cmd->_msg_to = args[0];
-	cmd->_msg = args[1].substr(1, args[1].length());
+	cmd->_msg_to = target;
+	cmd->_msg = msg.substr(1, msg.length());
 	if (cmd->_msg_to[0] == '#' || cmd->_msg_to[0] == '&') {
 		std::vector<Channel>::iterator channel = cmd->_state.getChannel(cmd->_msg_to);
 		if (channel == cmd->_state.getChannels().end()) {


### PR DESCRIPTION
# Problem overview
When a message is sent either to a channel or to another client, the message was partial.

# Fix
Now the PRIVMSG command takes in the target and the message instead of an argument vector. Now it's ensured that the whole message is sent. Resolves #39 