### PR TITLE
Server closing

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <signal.h>
 #include <cstring>
 #include <vector>
 #include <iostream>
@@ -21,12 +22,14 @@ class Server {
 		std::string			_port;
 		std::string			_password;
 		int					_server_socket;
-		State				_state;
+		State*				_state;
 
 	public:
 		Server(char** argv);
 		~Server();
 		void		start();
+		static void	stop(int signum);
+		void		closeServer();
 		std::string	getPort() const;
 		std::string	getPassword() const;
 		int			getServerSocket() const;

--- a/sources/Server.cpp
+++ b/sources/Server.cpp
@@ -80,6 +80,7 @@ void	Server::closeServer() {
 	close(_server_socket);
 	for (auto it = _state->_channels.begin(); it != _state->_channels.end(); ++it) {
 		it->_clients.clear();
+		it->_operators.clear();
 	}
 	_state->_channels.clear();
 	for (auto it = _state->_clients.begin(); it != _state->_clients.end(); ++it) {


### PR DESCRIPTION
# Changes
- Handling signals `SIGINT` and `SIGTSTP`
- Deletes all `Channel` objects and all instances of `Client` before exiting
- Closes all file descriptors before exiting
- Changed `Server`'s attribute `_state` to be an allocated pointer and deleting it before exiting to prevent memory leaks.

Resolves #37 