### PR TITLE
fixed epoll_wait fail check

### DIFF
--- a/sources/Server.cpp
+++ b/sources/Server.cpp
@@ -153,8 +153,7 @@ void Server::start() {
 				closeServer(0);
 			}
 			if (eventsCount < 0) {
-				std::cerr << "Error with epoll_wait" << std::endl;
-				break ;
+				throw std::runtime_error("epoll_wait failed: " + std::string(strerror(errno)));
 			}
 			if (eventsCount > 0) {
 				for (int i = 0; i < eventsCount; ++i) {


### PR DESCRIPTION
## What's new

1. If epoll_wait fails it now throws and error