### PR TITLE
fixed nickname with :

### DIFF
--- a/sources/NickCommand.cpp
+++ b/sources/NickCommand.cpp
@@ -10,7 +10,7 @@ std::unique_ptr<ACommand> NickCommand::create(std::string command, std::shared_p
 	NickCommand* cmd = new NickCommand(command, client, state);
 	Message msg;
 	std::string invalid_start = "$:#&~@+%";
-	std::string	invalid = " ,*?!@.";
+	std::string	invalid = " ,*?!@.:";
 
 	cmd->_nickname = nick;
 	if (cmd->_nickname.empty()) {

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 	if (input[0] == ':') {
 		input.erase(0, 1);
 	}
-	std::string nickname = input.substr(0, input.length());
+	std::string nickname = input.substr(0, input.find_first_of(' '));
 	return (NickCommand::create(command, client, state, nickname));
 }
 

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 	if (input[0] == ':') {
 		input.erase(0, 1);
 	}
-	size_t pos = input.find_first_not_of(" 	");
+	size_t pos = input.find_first_not_of(" \t");
 	input.erase(0, pos);
 	std::string nickname = input.substr(0, input.find_first_of(' '));
 	return (NickCommand::create(command, client, state, nickname));

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -139,6 +139,8 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 	if (input[0] == ':') {
 		input.erase(0, 1);
 	}
+	size_t pos = input.find_first_not_of(" 	");
+	input.erase(0, pos);
 	std::string nickname = input.substr(0, input.find_first_of(' '));
 	return (NickCommand::create(command, client, state, nickname));
 }

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -135,7 +135,11 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 	std::string& input, State& state) {
 
 	std::string command = input.substr(0, input.find_first_of(' '));
-	std::string nickname = input.substr(input.find_first_of(' ') + 1, input.length());
+	input.erase(0, command.length() + 1);
+	if (input[0] == ':') {
+		input.erase(0, 1);
+	}
+	std::string nickname = input.substr(0, input.length());
 	return (NickCommand::create(command, client, state, nickname));
 }
 


### PR DESCRIPTION
## What's new

1. Now parseNickCommand skips first leadin ":" character
2. Doesn't allow ":" anywhere else in the nickname