### PR TITLE
Server closing refactoring

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -25,17 +25,16 @@ class Server {
 		std::string _password;
 		int _server_socket;
 		State* _state;
-		bool _error;
+
 	public:
 		Server(char** argv);
 		~Server();
 		void start();
 		static void	stop(int signum);
-		void closeServer(int ret);
+		void closeServer();
 		std::string	getPort() const;
 		std::string	getPassword() const;
 		int	getServerSocket() const;
-		bool getError() const;
 		void handleNewClient(int epoll_fd);
 		void clientRegisteration(std::shared_ptr<Client>& client, Message& msg);
 		void receiveData(std::shared_ptr<Client>& client);

--- a/includes/State.hpp
+++ b/includes/State.hpp
@@ -15,6 +15,8 @@ class State {
         std::vector<std::shared_ptr<Client>> _clients;
         std::vector<Channel> _channels;
     public:
+        State();
+        ~State();
         std::string getServerName() const;
         std::vector<Channel>::iterator getChannel(std::string channel_name);
         std::vector<Channel> & getChannels();

--- a/sources/State.cpp
+++ b/sources/State.cpp
@@ -1,6 +1,20 @@
 
 #include "State.hpp"
 
+State::State() {}
+
+State::~State() {
+	for (auto it = _channels.begin(); it != _channels.end(); ++it) {
+		it->clients.clear();
+		it->operators.clear();
+	}
+	_channels.clear();
+	for (auto it = _clients.begin(); it != _clients.end(); ++it) {
+		it->reset();
+	}
+	_clients.clear();
+}
+
 std::string	State::getServerName() const {
 	return (_server_name);
 }

--- a/sources/main.cpp
+++ b/sources/main.cpp
@@ -11,13 +11,11 @@ int main(int argc, char **argv) {
         std::cerr << "Expected: ./ircserv <port> <password>" << std::endl;
         return (1);
     }
-    Server  ircserv(argv);
-    if (ircserv.getError()) {
-        std::cout << "Error in constructor" << std::endl;
-        return (1);
-    }
-    ircserv.start();
-    if (ircserv.getError()) {
+    try {    
+        Server  ircserv(argv);
+        ircserv.start();
+    } catch (std::exception& e) {
+        std::cerr << e.what() << std::endl;
         return (1);
     }
     return (0);


### PR DESCRIPTION
## Changes:
- `Server` constructor throws exceptions in an error occurs
- Constructing `Server` in a try-catch in `main()`
- Added a constructor and a destructor to `State` and moved vector clearing loops there for readability
- Removed unnecessary `_error` attribute from `Server` and the corresponding getter function
- `closeServer()` function is called only in case of success