### PR TITLE
Commands fix and cleanup

### DIFF
--- a/includes/KickCommand.hpp
+++ b/includes/KickCommand.hpp
@@ -10,6 +10,6 @@ class KickCommand : public ACommand {
         KickCommand(std::string command, std::shared_ptr<Client>& client, State& state);
     public:
         static std::unique_ptr<ACommand> create(std::string command, std::shared_ptr<Client>& client,
-            State& state, std::vector<std::string> args);
+            State& state, std::string channel, std::string nick, std::string message);
         void execute() const override;
 };

--- a/sources/InviteCommand.cpp
+++ b/sources/InviteCommand.cpp
@@ -39,6 +39,6 @@ void InviteCommand::execute() const {
 	}
 	msg.codedMessage(_client, _state, code, target);
 	if (code.code == RPL_INVITING.code) {
-		msg.message(_client, *invited_client, "INVITE", _invited_client, _channel);
+		msg.message(_client, *invited_client, _command, _invited_client, _channel);
 	}
 }

--- a/sources/KickCommand.cpp
+++ b/sources/KickCommand.cpp
@@ -3,16 +3,11 @@
 KickCommand::KickCommand(std::string command, std::shared_ptr<Client>& client, State& state) : ACommand(command, client, state) {}
 
 std::unique_ptr<ACommand> KickCommand::create(std::string command, std::shared_ptr<Client>& client, State& state,
-	std::vector<std::string> args) {
+	std::string channel, std::string nick, std::string message) {
 	KickCommand*	cmd = new KickCommand(command, client, state);
-    cmd->_channel = args[0];
-    cmd->_client_to_kick = args[1];
-    for (size_t i = 2; i < args.size(); i++) {
-        if (i >= 3) {
-            cmd->_msg += " ";
-        }
-        cmd->_msg += args[i];
-    }
+    cmd->_channel = channel;
+    cmd->_client_to_kick = nick;
+    cmd->_msg = message;
     return (std::unique_ptr<KickCommand>(cmd));
 }
 
@@ -49,6 +44,6 @@ void KickCommand::execute() const {
     }
     else {
         std::string target = _channel + " " + _client_to_kick;
-        msg.message(_client, _client, "KICK", target, _msg);
+        msg.message(_client, _client, _command, target, _msg);
     }
 }

--- a/sources/KickCommand.cpp
+++ b/sources/KickCommand.cpp
@@ -7,6 +7,12 @@ std::unique_ptr<ACommand> KickCommand::create(std::string command, std::shared_p
 	KickCommand*	cmd = new KickCommand(command, client, state);
     cmd->_channel = channel;
     cmd->_client_to_kick = nick;
+    if  (cmd->_client_to_kick == ":") {
+        Message msg;
+        msg.codedMessage(cmd->_client, state, ERR_NEEDMOREPARAMS, command);
+        delete cmd;
+        return (nullptr);
+    }
     cmd->_msg = message;
     return (std::unique_ptr<KickCommand>(cmd));
 }

--- a/sources/ModeCommand.cpp
+++ b/sources/ModeCommand.cpp
@@ -168,8 +168,8 @@ void ModeCommand::executeKey(Channel & channel, const mode_struct & mode_obj) co
             key = "*";
         }
         std::string mode = std::string("") + action_char + mode_char;
-        msg.message(_client, _client, "MODE", channel.getName() + " " + mode, key);
-        channel.sendMsgToAll(_client, "MODE", channel.getName() + " " + mode, key);
+        msg.message(_client, _client, _command, channel.getName() + " " + mode, key);
+        channel.sendMsgToAll(_client, _command, channel.getName() + " " + mode, key);
     }
     else {
         msg.codedMessage(_client, _state, reply, _channel_it->getName());
@@ -184,8 +184,8 @@ void ModeCommand::executeInvite(Channel & channel, const mode_struct & mode_obj)
         char action_char = static_cast<char>(mode_obj.action);
         char mode_char = static_cast<char>(mode_obj.mode);
         std::string mode = std::string("") + action_char + mode_char;
-        msg.message(_client, _client, "MODE", channel.getName() + " " + mode, {});
-        channel.sendMsgToAll(_client, "MODE", channel.getName() + " " + mode, {});
+        msg.message(_client, _client, _command, channel.getName() + " " + mode, {});
+        channel.sendMsgToAll(_client, _command, channel.getName() + " " + mode, {});
     }
     else {
         msg.codedMessage(_client, _state, reply, channel.getName());
@@ -200,8 +200,8 @@ void ModeCommand::executeTopic(Channel & channel, const mode_struct & mode_obj) 
         char action_char = static_cast<char>(mode_obj.action);
         char mode_char = static_cast<char>(mode_obj.mode);
         std::string mode = std::string("") + action_char + mode_char;
-        msg.message(_client, _client, "MODE", channel.getName() + " " + mode, {});
-        channel.sendMsgToAll(_client, "MODE", channel.getName() + " " + mode, {});
+        msg.message(_client, _client, _command, channel.getName() + " " + mode, {});
+        channel.sendMsgToAll(_client, _command, channel.getName() + " " + mode, {});
     }
     else {
         msg.codedMessage(_client, _state, reply, channel.getName());
@@ -234,12 +234,12 @@ void ModeCommand::executeLimit(Channel & channel, const mode_struct & mode_obj) 
         char mode_char = static_cast<char>(mode_obj.mode);
         std::string mode = std::string("") + action_char + mode_char;
         if (mode_obj.action == REMOVE && limit_before != -1) {
-            msg.message(_client, _client, "MODE", channel.getName() + " " + mode, {});
-            channel.sendMsgToAll(_client, "MODE", channel.getName() + " " + mode, {});
+            msg.message(_client, _client, _command, channel.getName() + " " + mode, {});
+            channel.sendMsgToAll(_client, _command, channel.getName() + " " + mode, {});
         }
         else if (mode_obj.action == ADD) {
-            msg.message(_client, _client, "MODE", channel.getName() + " " + mode, mode_obj.param);
-            channel.sendMsgToAll(_client, "MODE", channel.getName() + " " + mode, mode_obj.param);
+            msg.message(_client, _client, _command, channel.getName() + " " + mode, mode_obj.param);
+            channel.sendMsgToAll(_client, _command, channel.getName() + " " + mode, mode_obj.param);
         }
     }
     else {
@@ -270,8 +270,8 @@ void ModeCommand::executeOperator(Channel & channel, const mode_struct & mode_ob
         char action_char = static_cast<char>(mode_obj.action);
         char mode_char = static_cast<char>(mode_obj.mode);
         std::string mode = std::string("") + action_char + mode_char;
-        msg.message(_client, _client, "MODE", channel.getName() + " " + mode, mode_obj.param);
-        channel.sendMsgToAll(_client, "MODE", channel.getName() + " " + mode, mode_obj.param);
+        msg.message(_client, _client, _command, channel.getName() + " " + mode, mode_obj.param);
+        channel.sendMsgToAll(_client, _command, channel.getName() + " " + mode, mode_obj.param);
     }
     else {
         msg.codedMessage(_client, _state, reply, mode_obj.param);

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -102,15 +102,17 @@ std::unique_ptr<ACommand> Parser::parseKickCommmand(std::shared_ptr<Client>& cli
 	std::vector<std::string> arg_vec;
 	std::string command = input.substr(0, input.find_first_of(' '));
 	input.erase(0, command.length() + 1);
-	while (!input.empty()) {
-		std::string	arg = input.substr(0, input.find_first_of(' '));
-		input.erase(0, arg.length() + 1);
-		if (!input.empty() && input[0] == ':') {
-			input.erase(0, 1);
-		}
-		arg_vec.push_back(arg);
+	std::string channel = input.substr(0, input.find_first_of(' '));
+	input.erase(0, command.length() + 1);
+	input.erase(0, input.find_first_not_of(" \t"));
+	std::string nick = input.substr(0, input.find_first_of(' '));
+	input.erase(0, nick.length() + 1);
+	if (!input.empty() && input[0] == ':') {
+		input.erase(0, 1);
 	}
-	return (KickCommand::create(command, client, state, arg_vec));
+	std::string message = input;
+
+	return (KickCommand::create(command, client, state, channel, nick, message));
 }
 
 std::unique_ptr<ACommand> Parser::parseInviteCommand(std::shared_ptr<Client>& client,

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 	if (input[0] == ':') {
 		input.erase(0, 1);
 	}
-	size_t pos = input.find_first_not_of(" 	");
+	size_t pos = input.find_first_not_of(" \t");
 	input.erase(0, pos);
 	std::string nickname = input.substr(0, input.find_first_of(' '));
 	return (NickCommand::create(command, client, state, nickname));

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -138,9 +138,10 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 
 	std::string command = input.substr(0, input.find_first_of(' '));
 	input.erase(0, command.length() + 1);
-	if (input[0] == ':') {
+	// Do we want to do this to match other commands parsing?
+	/* if (input[0] == ':') { 
 		input.erase(0, 1);
-	}
+	} */
 	size_t pos = input.find_first_not_of(" \t");
 	input.erase(0, pos);
 	std::string nickname = input.substr(0, input.find_first_of(' '));

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -139,6 +139,8 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 	if (input[0] == ':') {
 		input.erase(0, 1);
 	}
+	size_t pos = input.find_first_not_of(" 	");
+	input.erase(0, pos);
 	std::string nickname = input.substr(0, input.find_first_of(' '));
 	return (NickCommand::create(command, client, state, nickname));
 }

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -99,7 +99,6 @@ std::unique_ptr<ACommand> Parser::parseQuitCommand(std::shared_ptr<Client>& clie
 std::unique_ptr<ACommand> Parser::parseKickCommmand(std::shared_ptr<Client>& client,
 	std::string& input, State& state) {
 
-	std::vector<std::string> arg_vec;
 	std::string command = input.substr(0, input.find_first_of(' '));
 	input.erase(0, command.length() + 1);
 	std::string channel = input.substr(0, input.find_first_of(' '));
@@ -121,7 +120,6 @@ std::unique_ptr<ACommand> Parser::parseKickCommmand(std::shared_ptr<Client>& cli
 std::unique_ptr<ACommand> Parser::parseInviteCommand(std::shared_ptr<Client>& client,
 	std::string& input, State& state) {
 
-	std::vector<std::string> arg_vec;
 	std::string command = input.substr(0, input.find_first_of(' '));
 	input.erase(0, command.length() + 1);
 	input.erase(0, input.find_first_not_of(" \t"));

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<ACommand> Parser::parseNickCommand(std::shared_ptr<Client>& clie
 
 	std::string command = input.substr(0, input.find_first_of(' '));
 	input.erase(0, command.length() + 1);
-	if (input[0] == ':') { 
+	if (input[0] == ':') {
 		input.erase(0, 1);
 	}
 	size_t pos = input.find_first_not_of(" \t");

--- a/sources/PrivmsgCommand.cpp
+++ b/sources/PrivmsgCommand.cpp
@@ -10,7 +10,7 @@ std::unique_ptr<ACommand> PrivmsgCommand::create(std::string command, std::share
 	PrivmsgCommand*	cmd = new PrivmsgCommand(command, client, state);
 	cmd->_msg_to = target;
 	cmd->_msg = msg.substr(1, msg.length());
-	if (cmd->_msg_to[0] == '#' || cmd->_msg_to[0] == '&') {
+	if (cmd->_msg_to[0] == '#') {
 		std::vector<Channel>::iterator channel = cmd->_state.getChannel(cmd->_msg_to);
 		if (channel == cmd->_state.getChannels().end()) {
 			delete cmd;

--- a/sources/PrivmsgCommand.cpp
+++ b/sources/PrivmsgCommand.cpp
@@ -16,6 +16,12 @@ std::unique_ptr<ACommand> PrivmsgCommand::create(std::string command, std::share
 			delete cmd;
 			return (nullptr);
 		}
+		else if (!channel->isClient(cmd->_client)) {
+			Message msg;
+			msg.codedMessage(cmd->_client, cmd->_state, ERR_CANNOTSENDTOCHAN, cmd->_msg_to);
+			delete cmd;
+			return (nullptr);
+		}
 		cmd->_channel = true;
 	}
 	else {


### PR DESCRIPTION
## Fixes:
- Handling empty `NICK` command correctly
- Parsing command arguments differently for better user experience

## Cleanup:
- Changed hard coded commands to `ACommand` attribute `_command`
- Changed `KICK` and `INVITE` parsing for readability