### PR TITLE
Makefile fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ ircserv
 *.log
 *.py
 __pycache__/
-objects_and_dependencies
+objects_and_dependencies/

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ all: $(OBJ_PATH) $(NAME)
 $(OBJ_PATH):
 	@$(COMPILING_OBJ)
 	@mkdir -p $(OBJ_PATH)
-#	$(OBJ_PATH)/name_of_folder
 
 $(OBJ_PATH)%.o: $(SRC_PATH)%.cpp $(INC)
 	@echo "$(YELLOW)⏳ Compiling $@...$(RESET)"


### PR DESCRIPTION
### Fixes:
Before we had a typo which caused the `Makefile` to not generate object files, but instead compile the program using `.cpp` files.
Now it generates object files in the `objects_and_depencies` directory.

### Changes:
- Generating dependency files (`.d`) so that a change in a header file is also taken into account when running `make`, this applies the changes to the program quicker and doesn't use that much resources from the computer. Resolves #93 
- Printing messages while compiling to inform the user of what's happening.