### PR TITLE
Command compare fix

### DIFF
--- a/includes/reply.hpp
+++ b/includes/reply.hpp
@@ -31,6 +31,7 @@ static const reply ERR_NOSUCHSERVER = {"402", "No such server"};
 static const reply ERR_CANNOTSENDTOCHAN = {"404", "Cannot send to channel"};
 static const reply ERR_NOSUCHCHANNEL = {"403",  "No such channel"};
 static const reply ERR_TOOMANYCHANNELS = {"405", "You have joined too many channels"};
+static const reply ERR_UNKNOWNCOMMAND = {"421", "Unknown command"};
 static const reply ERR_NONICKNAMEGIVEN = {"431", "No nickname given"};
 static const reply ERR_ERRONEUSNICKNAME = {"432", "Erroneus nickname"};
 static const reply ERR_NICKNAMEINUSE = {"433", "Nickname is already in use."};

--- a/sources/Message.cpp
+++ b/sources/Message.cpp
@@ -22,18 +22,20 @@ void Message::clearSendMsg() {
 }
 
 void Message::determineType(std::shared_ptr<Client>& client) {
-	if (_msg.compare(0, 4, "NICK") == 0 && client->getNickname().empty() && _type != CAP_LS) {
+	if (_msg.compare(0, 5, "NICK ") == 0 && client->getNickname().empty() && _type != CAP_LS) {
 		_send_msg = "CAP * ACK :multi-prefix\r\n";
 		_type = CAP_REQ_AGAIN;
 	}
-	else if (_msg.compare(0, 6, "CAP LS") == 0 || _msg.compare(0, 4, "PASS") == 0 \
-		|| _msg.compare(0, 4, "USER") == 0 || (_msg.compare(0, 4, "NICK") == 0 && _type == CAP_LS)) {
-		if (_msg.compare(0, 6, "CAP LS") == 0) {
+	else if (_msg.compare(0, 7, "CAP LS ") == 0  || _msg.compare("CAP LS") == 0 \
+		|| _msg.compare(0, 5, "PASS ") == 0 || _msg.compare("PASS") == 0 \
+		|| _msg.compare(0, 5, "USER ") == 0 || _msg.compare("USER") == 0 \
+		|| (_msg.compare(0, 5, "NICK ") == 0 && _type == CAP_LS)) {
+		if (_msg.compare(0, 7, "CAP LS ") == 0 || _msg.compare("CAP LS") == 0 ) {
 			_send_msg = "CAP * LS :multi-prefix account-notify account-tag invite-notify\r\n";
 		}
 		_type = CAP_LS;
 	}
-	else if (_msg.compare(0, 7, "CAP REQ") == 0) {
+	else if (_msg.compare(0, 8, "CAP REQ ") == 0 || _msg.compare("CAP REQ") == 0) {
 		if (!client->getNickname().empty()) {
 			_send_msg = "CAP " + client->getNickname() + " ACK :multi-prefix\r\n";
 		}
@@ -42,18 +44,14 @@ void Message::determineType(std::shared_ptr<Client>& client) {
 		}
 		_type = CAP_REQ;
 	}
-	else if (_msg.compare(0, 7, "CAP END") == 0) {
+	else if (_msg.compare(0, 8, "CAP END ") == 0 || _msg.compare("CAP END") == 0) {
 		_type = CAP_END;
 	}
-	else if (_msg.compare(0, 4, "JOIN") == 0 || _msg.compare(0, 7, "PRIVMSG") == 0 \
-		|| _msg.compare(0, 4, "NICK") == 0 || _msg.compare(0, 4, "QUIT") == 0 \
-		|| _msg.compare(0, 4, "KICK") == 0 || _msg.compare(0, 6, "INVITE") == 0 \
-		|| _msg.compare(0,4, "MODE") == 0 || _msg.compare(0, 5, "TOPIC") == 0 \
-		|| _msg.compare(0, 4, "WHO ") == 0 || _msg.compare(0,5, "WHOIS") == 0 ) {
-		_type = CMD;
-	}
-	else if (_msg.compare(0, 4, "PING") == 0) {
+	else if (_msg.compare(0, 5, "PING ") == 0 || _msg.compare("PING") == 0) {
 		_type = PING;
+	}
+	else {
+		_type = CMD;
 	}
 }
 

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -2,17 +2,17 @@
 
 void Parser::parseCap(std::shared_ptr<Client>& client, std::string& input, State& state) {
 	try {
-		if (input.compare(0, 6, "CAP LS") == 0) {
+		if (input.compare(0, 7, "CAP LS ") == 0  || input.compare("CAP LS") == 0 ) {
 			return ;
 		}
-		else if (input.compare(0, 4, "PASS") == 0) {
+		else if (input.compare(0, 5, "PASS ") == 0 || input.compare("PASS") == 0 ) {
 			std::string	password = input.substr(5, input.length());
 			client->setPassword(password);
-		} else if (input.compare(0, 4, "NICK") == 0) {
+		} else if (input.compare(0, 5, "NICK ") == 0 || input.compare("NICK") == 0) {
 			std::unique_ptr<ACommand> cmd = parseNickCommand(client, input, state);
 			if (cmd != nullptr)
 				cmd->execute();
-		} else if (input.compare(0, 4, "USER") == 0) {
+		} else if (input.compare(0, 5, "USER ") == 0 || input.compare("USER") == 0) {
 			std::string	args = input.substr(5, input.length());
 			std::string	username = args.substr(0, args.find(' '));
 			args = args.substr(username.length() + 1, args.length());
@@ -28,40 +28,43 @@ void Parser::parseCap(std::shared_ptr<Client>& client, std::string& input, State
 std::unique_ptr<ACommand> Parser::parseCommand(std::shared_ptr<Client>& client, std::string& input,
 	State& state) {
 
+	std::string command = input.substr(0, input.find_first_of(' '));
 	try {
-		if (input.compare(0, 4, "JOIN") == 0) {
+		if (command.compare("JOIN") == 0) {
 			return (parseJoinCommand(client, input, state));
 		}
-		else if (input.compare(0, 7, "PRIVMSG") == 0) {
+		else if (command.compare("PRIVMSG") == 0) {
 			return (parsePrivmsgCommand(client, input, state));
 		}
-		else if (input.compare(0, 4, "MODE") == 0) {
+		else if (command.compare("MODE") == 0) {
 			return (parseModeCommand(client, input, state));
 		}
-		else if (input.compare(0, 4, "QUIT") == 0) {
+		else if (command.compare("QUIT") == 0) {
 			return (parseQuitCommand(client, input, state));
 		}
-		else if (input.compare(0, 4, "NICK") == 0) {
+		else if (command.compare("NICK") == 0) {
 			return (parseNickCommand(client, input, state));
 		}
-		else if (input.compare(0, 4, "KICK") == 0) {
+		else if (command.compare("KICK") == 0) {
 			return (parseKickCommmand(client, input, state));
 		}
-		else if (input.compare(0, 6, "INVITE") == 0) {
+		else if (command.compare("INVITE") == 0) {
 			return (parseInviteCommand(client, input, state));
 		}
-		else if (input.compare(0, 5, "TOPIC") == 0) {
+		else if (command.compare("TOPIC") == 0) {
 			return (parseTopicCommand(client, input, state));
 		}
-		else if (input.compare(0, 4, "WHO ") == 0) {
+		else if (command.compare("WHO") == 0) {
 			return (parseWhoCommand(client, input, state));
 		}
-		else if (input.compare(0,5, "WHOIS") == 0) {
+		else if (command.compare("WHOIS") == 0) {
 			return (parseWhoisCommand(client, input, state));
 		}
 	} catch (std::exception& e) {
 		std::cerr << e.what() << std::endl;
 	}
+	Message msg;
+	msg.codedMessage(client, state, ERR_UNKNOWNCOMMAND, command);
 	return (nullptr);
 }
 


### PR DESCRIPTION
Refactored the parsing of commands so that only "CMD " or "CMD\0" will be interpreted as that command. 

Also added an error response if the command is unknown to the server.

Resolves #96 