### PR TITLE
Registration fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 ircserv
 *.log
 *.py
+*.sh
 __pycache__/
 objects_and_dependencies/

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -23,6 +23,7 @@ class Client {
 		std::vector<std::string> _invited_to;
 		bool		_nick_validated;
 		bool		_pass_validated;
+		bool		_pass_set;
 		int			_registration_attempts;
 
 	public:
@@ -44,6 +45,7 @@ class Client {
 		bool		isAuthenticated() const;
 		bool		isValidPass() const;
 		bool		isInvited(const std::string& channel_name) const;
+		bool		isPassSet() const;
 		void 		setNickname(std::string nickname);
 		void		setUsername(std::string username);
 		void		setHostname(std::string hostname);

--- a/sources/Client.cpp
+++ b/sources/Client.cpp
@@ -1,14 +1,14 @@
 #include "Client.hpp"
 
 Client::Client(int socket, int epoll_fd, std::string ip) : _client_socket(socket), _epoll_fd(epoll_fd), _name(""), _nickname(""), _username(""), _hostname(ip), _password(""), \
-														_authenticated(false), _nick_validated(false), _pass_validated(true), _registration_attempts(0) {
+														_authenticated(false), _nick_validated(false), _pass_validated(true), _pass_set(false), _registration_attempts(0) {
 
 }
 
 Client::Client(Client&& old_client) noexcept : _client_socket(old_client._client_socket), _epoll_fd(old_client._epoll_fd), _name(old_client._name), _nickname(old_client._nickname), \
 											_username(old_client._username), _hostname(old_client._hostname), _password(old_client._password), _buffer(old_client._buffer), \
 											_send_buffer(old_client._send_buffer), _nick_validated(old_client._nick_validated), _pass_validated(old_client._pass_validated), \
-											_registration_attempts(old_client._registration_attempts) {
+											_pass_set(old_client._pass_set), _registration_attempts(old_client._registration_attempts) {
 
 }
 
@@ -68,6 +68,10 @@ bool Client::isValidPass() const {
 	return (_pass_validated);
 }
 
+bool Client::isPassSet() const {
+	return (_pass_set);
+}
+
 void Client::setNickname(std::string nickname) {
 	_nickname = nickname;
 }
@@ -86,6 +90,7 @@ void Client::setName(std::string name) {
 
 void Client::setPassword(std::string password) {
 	_password = password;
+	_pass_set = true;
 }
 
 void Client::setValidPass(bool set) {

--- a/sources/Message.cpp
+++ b/sources/Message.cpp
@@ -28,7 +28,7 @@ void Message::determineType(std::shared_ptr<Client>& client) {
 		_type = REG;
 	}
 	else if (cmd.compare("PASS") == 0 || cmd.compare("USER") == 0 \
-		|| (cmd.compare("NICK") == 0 && client->getNickname().empty())) {
+		|| (cmd.compare("NICK") == 0 && !client->isAuthenticated())) {
 		_type = REG;
 	}
 	else if (cmd.compare("PING") == 0) {

--- a/sources/Parser.cpp
+++ b/sources/Parser.cpp
@@ -2,8 +2,10 @@
 
 void Parser::parseRegisteration(std::shared_ptr<Client>& client, std::string& input, State& state) {
 	try {
-		std::string command = input.substr(0, input.find_first_of(' '));
+		std::string whitespace = " \t\r\n\t\v";
+		std::string command = input.substr(0, input.find_first_of(whitespace));
 		input.erase(0, command.length() + 1);
+		input.erase(0, input.find_first_not_of(whitespace));
 		if (command.compare("CAP") == 0) {
 			return ;
 		}
@@ -16,11 +18,12 @@ void Parser::parseRegisteration(std::shared_ptr<Client>& client, std::string& in
 		} else if (command.compare("USER") == 0) {
 			try {
 				short int args = 1;
-				for (std::string::iterator it = input.begin(); it != input.end(); ++it) {
-					if (*it == ':') {
+				for (size_t i = 0; i < input.length(); ++i) {
+					if (input[i] == ':') {
 						break ;
 					}
-					if (*it == ' ') {
+					if (whitespace.find(input[i]) != std::string::npos) {
+						i = input.find_first_not_of(whitespace, i) - 1;
 						args++;
 					}
 				}
@@ -74,9 +77,28 @@ void Parser::parseRegisteration(std::shared_ptr<Client>& client, std::string& in
 std::unique_ptr<ACommand> Parser::parseCommand(std::shared_ptr<Client>& client, std::string& input,
 	State& state) {
 
-	std::string command = input.substr(0, input.find_first_of(' '));
-	input.erase(0, command.length() + 1);
+	std::string command;
+
 	try {
+		std::string whitespace = " \t\r\n\t\v";
+		input.erase(0, input.find_first_not_of(whitespace));
+		command = input.substr(0, input.find_first_of(whitespace));
+		input.erase(0, command.length() + 1);
+		for (size_t i = 0; i < input.length(); ++i) {
+			if (input[i] == ':') {
+				break ;
+			}
+			if (whitespace.find(input[i]) != std::string::npos) {
+				std::cout << "space found at index: " << i << "	up until: " << input.find_first_not_of(' ', i + 1) << "	Characters to remove: " << input.find_first_not_of(' ', i + 1) - (i + 1) << std::endl;
+				input.erase(i, input.find_first_not_of(whitespace, i) - i);
+				input.insert(i, 1, ' ');
+				std::cout << input << std::endl;
+			}
+			if (i > input.length()) {
+				break ;
+			}
+		}
+		input.erase(0, input.find_first_not_of(whitespace));
 		if (command.compare("JOIN") == 0) {
 			return (parseJoinCommand(client, command, input, state));
 		}

--- a/sources/Server.cpp
+++ b/sources/Server.cpp
@@ -262,7 +262,7 @@ void Server::receiveData(std::shared_ptr<Client>& client) {
 }
 
 bool Server::validatePassword(std::shared_ptr<Client>& client) {
-	if (client->getPassword().empty()) {
+	if (!client->isPassSet()) {
 		return (true);
 	}
 	else if (client->getPassword() != _password && client->isValidPass()) {


### PR DESCRIPTION
## Fixes resolves #120

- Fixed issue in `PASS`. If `PASS` is sent without parameters it assigns an empty password to the client, if that does not match the servers password, denies access from the client. Resolves #110 
- Allowing clients to change their nickname while registering. Resolves #108 
- Fixed parameter counter bug in `USER`. Resolves #109 

## Additional changes:
`Parser` now removes all whitespace from the input string and inserts a space where it's needed. This is to make sure that the input string is always valid and that we process it correctly, without sending too many error messages to the client.